### PR TITLE
README: remove the duplicate

### DIFF
--- a/README
+++ b/README
@@ -1,7 +1,0 @@
-Purple Facebook implements the Facebook Messenger protocol into pidgin,
-finch, and libpurple. While the primary implementation is for purple3,
-this plugin is back-ported for purple2.
-
-This project is not affiliated with Facebook, Inc.
-
-More information: https://github.com/dequis/purple-facebook/wiki

--- a/README.md
+++ b/README.md
@@ -1,1 +1,7 @@
-README
+Purple Facebook implements the Facebook Messenger protocol into pidgin,
+finch, and libpurple. While the primary implementation is for purple3,
+this plugin is back-ported for purple2.
+
+This project is not affiliated with Facebook, Inc.
+
+More information: https://github.com/dequis/purple-facebook/wiki


### PR DESCRIPTION
Having 2 README files is unnecessary, doubles the effort, and forces
people to check them both though in fact they're identical.

Signed-off-by: Constantine Kharlamov <Hi-Angel@yandex.ru>