### PR TITLE
Small code fixes

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,7 @@
 language: c
 
+dist: xenial
+
 notifications:
   email: false
 
@@ -32,12 +34,14 @@ before_install:
       libjson-glib-dev
       libpurple-dev
       osc
-  - mkdir -p ~/.ssh
-  - openssl aes-256-cbc
-      -K $encrypted_1a8668021c4a_key
-      -iv $encrypted_1a8668021c4a_iv
-      -in .travis/key -out ~/.ssh/id_rsa -d
-  - chmod 600 ~/.ssh/id_rsa
+  - if [ "x$TRAVIS_EVENT_TYPE" != "xpull_request" ]; then
+      mkdir -p ~/.ssh;
+      openssl aes-256-cbc
+        -K $encrypted_1a8668021c4a_key
+        -iv $encrypted_1a8668021c4a_iv
+        -in .travis/key -out ~/.ssh/id_rsa -d;
+      chmod 600 ~/.ssh/id_rsa;
+    fi
 
 install:
   - .travis/win32-install.sh
@@ -53,9 +57,13 @@ script:
   - .travis/win32-build.sh
 
 after_success:
-  - .travis/win32-deploy.sh
-  - .travis/obs.sh
+  - if [ "x$TRAVIS_EVENT_TYPE" != "xpull_request" ]; then
+      .travis/win32-deploy.sh;
+      .travis/obs.sh;
+    fi
 
 after_script:
-  - shred ~/.ssh/id_rsa
-  - rm -f ~/.ssh/id_rsa
+  - if [ "x$TRAVIS_EVENT_TYPE" != "xpull_request" ]; then
+      shred ~/.ssh/id_rsa;
+      rm -f ~/.ssh/id_rsa;
+    fi

--- a/configure.ac
+++ b/configure.ac
@@ -80,6 +80,7 @@ AC_ARG_WITH(
 PKG_CHECK_MODULES([GLIB], [glib-2.0 >= 2.28.0 gio-2.0 gobject-2.0])
 PKG_CHECK_MODULES([JSON], [json-glib-1.0 >= 0.14.0])
 PKG_CHECK_MODULES([PURPLE], [purple <  3])
+PKG_CHECK_MODULES([ZLIB], [zlib])
 
 PKG_CHECK_VAR([GLIB_GENMARSHAL], [glib-2.0], [glib_genmarshal])
 AS_IF(

--- a/patches/15-glib-deprecate-g_type_class_add_private.patch
+++ b/patches/15-glib-deprecate-g_type_class_add_private.patch
@@ -1,0 +1,99 @@
+Index: libpurple/protocols/facebook/api.c
+===================================================================
+--- a/libpurple/protocols/facebook/api.c
++++ b/libpurple/protocols/facebook/api.c
+@@ -92,7 +92,7 @@ fb_api_sticker(FbApi *api, FbId sid, FbA
+ void
+ fb_api_contacts_delta(FbApi *api, const gchar *delta_cursor);
+ 
+-G_DEFINE_TYPE(FbApi, fb_api, G_TYPE_OBJECT);
++G_DEFINE_TYPE_WITH_CODE(FbApi, fb_api, G_TYPE_OBJECT, G_ADD_PRIVATE(FbApi));
+ 
+ static void
+ fb_api_set_property(GObject *obj, guint prop, const GValue *val,
+Index: libpurple/protocols/facebook/data.c
+===================================================================
+--- a/libpurple/protocols/facebook/data.c
++++ b/libpurple/protocols/facebook/data.c
+@@ -59,8 +59,8 @@ static const gchar *fb_props_strs[] = {
+ 	"token"
+ };
+ 
+-G_DEFINE_TYPE(FbData, fb_data, G_TYPE_OBJECT);
+-G_DEFINE_TYPE(FbDataImage, fb_data_image, G_TYPE_OBJECT);
++G_DEFINE_TYPE_WITH_CODE(FbData, fb_data, G_TYPE_OBJECT, G_ADD_PRIVATE(FbData));
++G_DEFINE_TYPE_WITH_CODE(FbDataImage, fb_data_image, G_TYPE_OBJECT, G_ADD_PRIVATE(FbDataImage));
+ 
+ static void
+ fb_data_dispose(GObject *obj)
+Index: libpurple/protocols/facebook/json.c
+===================================================================
+--- a/libpurple/protocols/facebook/json.c
++++ b/libpurple/protocols/facebook/json.c
+@@ -25,6 +25,7 @@
+ #include <string.h>
+ 
+ #include "json.h"
++#include "glibcompat.h"
+ #include "util.h"
+ 
+ typedef struct _FbJsonValue FbJsonValue;
+@@ -50,7 +51,7 @@ struct _FbJsonValuesPrivate
+ 	GError *error;
+ };
+ 
+-G_DEFINE_TYPE(FbJsonValues, fb_json_values, G_TYPE_OBJECT);
++G_DEFINE_TYPE_WITH_CODE(FbJsonValues, fb_json_values, G_TYPE_OBJECT, G_ADD_PRIVATE(FbJsonValues));
+ 
+ static void
+ fb_json_values_dispose(GObject *obj)
+Index: libpurple/protocols/facebook/mqtt.c
+===================================================================
+--- a/libpurple/protocols/facebook/mqtt.c
++++ b/libpurple/protocols/facebook/mqtt.c
+@@ -62,8 +62,8 @@ struct _FbMqttMessagePrivate
+ 	gboolean local;
+ };
+ 
+-G_DEFINE_TYPE(FbMqtt, fb_mqtt, G_TYPE_OBJECT);
+-G_DEFINE_TYPE(FbMqttMessage, fb_mqtt_message, G_TYPE_OBJECT);
++G_DEFINE_TYPE_WITH_CODE(FbMqtt, fb_mqtt, G_TYPE_OBJECT, G_ADD_PRIVATE(FbMqtt));
++G_DEFINE_TYPE_WITH_CODE(FbMqttMessage, fb_mqtt_message, G_TYPE_OBJECT, G_ADD_PRIVATE(FbMqttMessage));
+ 
+ static void
+ fb_mqtt_dispose(GObject *obj)
+Index: libpurple/protocols/facebook/thrift.c
+===================================================================
+--- a/libpurple/protocols/facebook/thrift.c
++++ b/libpurple/protocols/facebook/thrift.c
+@@ -21,6 +21,7 @@
+ 
+ #include <string.h>
+ 
++#include "glibcompat.h"
+ #include "thrift.h"
+ 
+ struct _FbThriftPrivate
+@@ -32,7 +33,7 @@ struct _FbThriftPrivate
+ 	guint lastbool;
+ };
+ 
+-G_DEFINE_TYPE(FbThrift, fb_thrift, G_TYPE_OBJECT);
++G_DEFINE_TYPE_WITH_CODE(FbThrift, fb_thrift, G_TYPE_OBJECT, G_ADD_PRIVATE(FbThrift));
+ 
+ static void
+ fb_thrift_dispose(GObject *obj)
+Index: libpurple/glibcompat.h
+===================================================================
+--- a/libpurple/glibcompat.h
++++ b/libpurple/glibcompat.h
+@@ -110,6 +110,9 @@ static inline void g_queue_free_full(GQu
+                                                g_assertion_message (G_LOG_DOMAIN, __FILE__, __LINE__, G_STRFUNC, \
+                                                                     "'" #expr "' should be NULL"); \
+                                         } G_STMT_END
++#define G_ADD_PRIVATE(TypeName)         G_STMT_START { } G_STMT_END
++#else
++#define g_type_class_add_private(k,s)   G_STMT_START { } G_STMT_END
+ #endif
+ 
+ #if !GLIB_CHECK_VERSION(2, 40, 0)

--- a/patches/16-fix-duplicate-decl-specifier.patch
+++ b/patches/16-fix-duplicate-decl-specifier.patch
@@ -1,0 +1,13 @@
+Index: libpurple/protocols/facebook/http.c
+===================================================================
+--- a/libpurple/protocols/facebook/http.c
++++ b/libpurple/protocols/facebook/http.c
+@@ -381,7 +381,7 @@ fb_http_urlcmp(const gchar *url1, const
+ 	PurpleHttpURL *purl1;
+ 	PurpleHttpURL *purl2;
+ 
+-	static const const gchar * (*funcs[]) (const PurpleHttpURL *url) = {
++	static const gchar * (*funcs[]) (const PurpleHttpURL *url) = {
+ 		/* Always first so it can be skipped */
+ 		purple_http_url_get_protocol,
+ 


### PR DESCRIPTION
This PR fixes two compiler warnings:
* The function `g_type_class_add_private()` has been deprecated in [glib v2.58](https://gitlab.gnome.org/GNOME/glib/commit/7e5db31d36532274c2b2428ef9bace796928785e).
* `const const` is _not_ a valid declaration specifier.

***

Tested with RHEL 6 / 7 and Fedora 27 / 28 / 29 (Beta).