### PR TITLE
Include case 6 for optional thrift fields

### DIFF
--- a/patches/18-fix-thrift-stop-failure.patch
+++ b/patches/18-fix-thrift-stop-failure.patch
@@ -1,0 +1,11 @@
+--- a/libpurple/protocols/facebook/api.c
++++ b/libpurple/protocols/facebook/api.c
+@@ -1847,7 +1847,7 @@
+ 		fb_util_debug_info("Presence: %" FB_ID_FORMAT " (%d)",
+ 		                   i64, i32 != 0);
+ 
+-		while (id <= 5) {
++		while (id <= 6) {
+ 			if (fb_thrift_read_isstop(thft)) {
+ 				break;
+ 			}


### PR DESCRIPTION
Up until this fix I have been frequently (although somewhat intermittently) dealing with `Failed to read thrift: api.c:1893 fb_api_cb_public_pt: assertion 'fb_frist_read_stop(thft)' failed` across logins (issue #468) 

After a bit of digging, it seems that at some point `case 6` was added to read optional thrift fields, however the enclosing loop only allows control to loop back around and call `fb_thrift_read_field()` up until case 5. 

I'll admit I don't have much experience with Thrift, however after applying this patch to my own build I haven't been able to reproduce. I was hoping someone could take a look at this and see if this is correct. 