### PR TITLE
Fix `Failed to read thrift ... assertion 'id == 2' failed`

### DIFF
--- a/patches/19-fix-taNewMessage-bug.patch
+++ b/patches/19-fix-taNewMessage-bug.patch
@@ -14,7 +14,7 @@
 +
 +		FB_API_TCHK(fb_thrift_read_field(thft, &type, &id, 0));
 +		FB_API_TCHK(type == FB_THRIFT_TYPE_STRING);
-+		FB_API_TCHK(id == 2);
++		// FB_API_TCHK(id == 2);
 +		FB_API_TCHK(fb_thrift_read_str(thft, NULL));
 +		FB_API_TCHK(fb_thrift_read_stop(thft));
 +	}


### PR DESCRIPTION
This probably isn't the best fix, but it seems to make Facebook
connections stable for me.

After applying PR #497 you end up with frequent disconnects with:

```
Failed to read thrift: api.c:1515 fb_api_cb_publish_mst: assertion 'id == 2' failed
```

@baltitenger said they checked that because that was the value in the
messages they saw, and they didn't know what other values would mean.

It seems messages with a different value don't break things (but we're
probably not handling them properly), but not crashing on them is
certainly better than crashing on them.

Fixes #496